### PR TITLE
chore: Update GitHub Actions to v4 in CI workflows

### DIFF
--- a/.github/workflows/drishti-darshan-3.4.0.yml
+++ b/.github/workflows/drishti-darshan-3.4.0.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload Artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tests
           path: sample/**

--- a/.github/workflows/drishti-darshan-3.4.0.yml
+++ b/.github/workflows/drishti-darshan-3.4.0.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/drishti-darshan-3.4.1.yml
+++ b/.github/workflows/drishti-darshan-3.4.1.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload Artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tests
           path: sample/**

--- a/.github/workflows/drishti-darshan-3.4.1.yml
+++ b/.github/workflows/drishti-darshan-3.4.1.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 

--- a/.github/workflows/drishti-darshan-3.4.2.yml
+++ b/.github/workflows/drishti-darshan-3.4.2.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload Artifact
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tests
           path: sample/**

--- a/.github/workflows/drishti-darshan-3.4.2.yml
+++ b/.github/workflows/drishti-darshan-3.4.2.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 


### PR DESCRIPTION
## Overview
Updates GitHub Actions from v2 to v4 across all Drishti Darshan 3.4.x workflow files.

## Commits
- 0572f9c - chore: Update GitHub Actions to use checkout@v4
- 8354240 - chore: Update GitHub Actions to use upload-artifact@v4

## Files Modified
- `.github/workflows/drishti-darshan-3.4.0.yml`
- `.github/workflows/drishti-darshan-3.4.1.yml`
- `.github/workflows/drishti-darshan-3.4.2.yml`

## Changes
- Updated `actions/checkout@v2` → `actions/checkout@v4`
- Updated `actions/upload-artifact@v2` → `actions/upload-artifact@v4`

## Motivation
These updates ensure we're using the latest GitHub Actions, as v2 has been deprecated.

## Risk Assessment
Low risk - these are standard GitHub Action upgrades with backward compatibility.
