### PR TITLE
Fix issues with new pandas version

### DIFF
--- a/drishti/handlers/handle_darshan.py
+++ b/drishti/handlers/handle_darshan.py
@@ -357,7 +357,7 @@ def handler():
 
         detected_files = pd.DataFrame(df['counters'].groupby('id')[['INSIGHTS_POSIX_SMALL_READ', 'INSIGHTS_POSIX_SMALL_WRITE']].sum()).reset_index()
         detected_files.columns = ['id', 'total_reads', 'total_writes']
-        detected_files.loc[:, 'id'] = detected_files.loc[:, 'id'].astype(str)
+        detected_files['id'] = detected_files['id'].astype(str)
 
         check_small_operation(total_reads, total_reads_small, total_writes, total_writes_small, detected_files, modules, file_map, dxt_posix, dxt_posix_read_data, dxt_posix_write_data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-darshan>=3.4
+darshan
 pandas>=2
 rich>=12.5.1
 recorder-utils

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt") as f:
 setup(
     name="drishti-io",
     keywords="drishti",
-    version="0.7.2",
+    version="0.7.4",
     author="Jean Luca Bez, Suren Byna",
     author_email="jlbez@lbl.gov, sbyna@lbl.gov",
     description="",
@@ -18,7 +18,7 @@ setup(
     url="https://github.com/hpc-io/drishti",
     install_requires=[
         'pandas>=2',
-        'darshan>=3.4',
+        'darshan',
         'rich>=12.5.1',
         'recorder-utils',
     ],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("requirements.txt") as f:
 setup(
     name="drishti-io",
     keywords="drishti",
-    version="0.7.4",
+    version="0.7",
     author="Jean Luca Bez, Suren Byna",
     author_email="jlbez@lbl.gov, sbyna@lbl.gov",
     description="",


### PR DESCRIPTION
Fix the issue with casting in new pandas (`pandas.errors.LossySetitemError`):

```
TypeError: Invalid value '<ArrowStringArray>
['4718013374827475928']
Length: 1, dtype: str' for dtype 'int64'
```