### PR TITLE
Add misaligned request check for recorder handler

### DIFF
--- a/drishti/handlers/handle_recorder.py
+++ b/drishti/handlers/handle_recorder.py
@@ -197,8 +197,14 @@ def process_helper(file_map, df_intervals, df_posix_records, fid=None):
 
         #########################################################################################################################################################################
 
-        # How many requests are misaligned?
-        # TODO: 
+        # How many requests are misaligned? (file offset/size vs 4K block)
+        block = 4096
+        has_offset = df_posix['offset'].notna() & df_posix['size'].notna()
+        if has_offset.any():
+            off = df_posix.loc[has_offset, 'offset']
+            sz = df_posix.loc[has_offset, 'size']
+            total_file_not_aligned = ((off % block != 0) | ((off + sz) % block != 0)).sum()
+            check_misaligned(total_operations, 0, int(total_file_not_aligned), modules, file_map)
 
         #########################################################################################################################################################################
 


### PR DESCRIPTION
The recorder path had a TODO for checking misaligned requests; the Darshan path already does this via POSIX_FILE_NOT_ALIGNED / POSIX_MEM_NOT_ALIGNED. This adds the same kind of check for recorder by deriving file alignment from offset/size in the POSIX intervals (4K block). When enough ops are misaligned we call the existing check_misaligned() so recorder users get the same recommendation as Darshan.
