### PR TITLE
Move flake8 config to project root

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 160
+exclude = .git,__pycache__,docs/source/conf.py,build,dist

--- a/.github/workflows/[flake8]
+++ b/.github/workflows/[flake8]
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 160
-exclude = .git,__pycache__,docs/source/conf.py,build,dist


### PR DESCRIPTION
Flake8 only picks up config from the repo root (e.g. .flake8), so the one under .github/workflows/ was never used. Added .flake8 at the root with the same settings and removed the old file so lint uses it correctly.