### PR TITLE
fix: read version dynamically instead of hardcoding v.0.5

### DIFF
--- a/drishti/__init__.py
+++ b/drishti/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("drishti-io")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/drishti/__init__.py
+++ b/drishti/__init__.py
@@ -1,4 +1,7 @@
-from importlib.metadata import version, PackageNotFoundError
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:  # Python < 3.8
+    from importlib_metadata import version, PackageNotFoundError
 
 try:
     __version__ = version("drishti-io")

--- a/drishti/handlers/handle_darshan.py
+++ b/drishti/handlers/handle_darshan.py
@@ -16,7 +16,6 @@ from drishti.includes.module import *
 from rich import print
 from packaging import version
 from drishti import __version__
-from drishti.includes.module import *
 
 
 def is_available(name):

--- a/drishti/handlers/handle_darshan.py
+++ b/drishti/handlers/handle_darshan.py
@@ -13,6 +13,10 @@ import darshan.backend.cffi_backend as darshanll
 from rich import print
 from packaging import version
 from drishti.includes.module import *
+from rich import print
+from packaging import version
+from drishti import __version__
+from drishti.includes.module import *
 
 
 def is_available(name):
@@ -734,7 +738,7 @@ def handler():
                     ' '.join(hints)
                 )
             ]),
-            title='[b][slate_blue3]DRISHTI[/slate_blue3] v.0.5[/b]',
+            title='[b][slate_blue3]DRISHTI[/slate_blue3] v.{}[/b]'.format(__version__),
             title_align='left',
             subtitle='[red][b]{} critical issues[/b][/red], [orange1][b]{} warnings[/b][/orange1], and [white][b]{} recommendations[/b][/white]'.format(
                 insights_total[HIGH],

--- a/drishti/handlers/handle_darshan.py
+++ b/drishti/handlers/handle_darshan.py
@@ -13,8 +13,6 @@ import darshan.backend.cffi_backend as darshanll
 from rich import print
 from packaging import version
 from drishti.includes.module import *
-from rich import print
-from packaging import version
 from drishti import __version__
 
 

--- a/drishti/handlers/handle_recorder.py
+++ b/drishti/handlers/handle_recorder.py
@@ -7,6 +7,7 @@ import pandas as pd
 from recorder_utils import RecorderReader
 from recorder_utils.build_offset_intervals import build_offset_intervals
 
+from drishti import __version__
 from drishti.includes.module import *
 
 
@@ -533,7 +534,7 @@ def process_helper(file_map, df_intervals, df_posix_records, fid=None):
                         df_intervals['rank'].nunique()
                     ),
                 ]),
-                title='[b][slate_blue3]DRISHTI[/slate_blue3] v.0.5[/b]',
+                title='[b][slate_blue3]DRISHTI[/slate_blue3] v.{}[/b]'.format(__version__),
                 title_align='left',
                 subtitle='[red][b]{} critical issues[/b][/red], [orange1][b]{} warnings[/b][/orange1], and [white][b]{} recommendations[/b][/white]'.format(
                     insights_total[HIGH],
@@ -561,7 +562,7 @@ def process_helper(file_map, df_intervals, df_posix_records, fid=None):
                         df_intervals['rank'].nunique()
                     ),
                 ]),
-                title='[b][slate_blue3]DRISHTI[/slate_blue3] v.0.5[/b]',
+                title='[b][slate_blue3]DRISHTI[/slate_blue3] v.{}[/b]'.format(__version__),
                 title_align='left',
                 subtitle='[red][b]{} critical issues[/b][/red], [orange1][b]{} warnings[/b][/orange1], and [white][b]{} recommendations[/b][/white]'.format(
                     insights_total[HIGH],


### PR DESCRIPTION
Fixed #39 

Version string was hardcoded as v.0.5 in handle_darshan.py and handle_recorder.py despite the package being at version 0.8. Now reads version dynamically from package metadata using importlib.metadata, so the displayed version always matches the installed package version.

<img width="1400" height="197" alt="image" src="https://github.com/user-attachments/assets/e8302639-a709-41d6-b19d-8cb7ddb9ce48" />
