### PR TITLE
fix: improve input validation in check_log_type

### DIFF
--- a/drishti/reporter.py
+++ b/drishti/reporter.py
@@ -34,10 +34,12 @@ def check_log_type(path):
         if not os.path.isfile(path):
             print('Unable to open .darshan file.')
             sys.exit(os.EX_NOINPUT)
-        else: 
+        else:
             return LOG_TYPE_DARSHAN
     elif os.path.isdir(path):
         return LOG_TYPE_RECORDER
+    elif not os.path.exists(path):
+        sys.exit('Error: Path does not exist: {}'.format(path))
     else:
         print('Unsupported file format. Please provide a .darshan file or a Recorder directory.')
         sys.exit(1)

--- a/drishti/reporter.py
+++ b/drishti/reporter.py
@@ -34,12 +34,13 @@ def check_log_type(path):
         if not os.path.isfile(path):
             print('Unable to open .darshan file.')
             sys.exit(os.EX_NOINPUT)
-        else: return LOG_TYPE_DARSHAN
-    else: # check whether is a valid recorder log
-        if not os.path.isdir(path):
-            print('Unable to open recorder folder.')
-            sys.exit(os.EX_NOINPUT)
-        else: return LOG_TYPE_RECORDER
+        else: 
+            return LOG_TYPE_DARSHAN
+    elif os.path.isdir(path):
+        return LOG_TYPE_RECORDER
+    else:
+        print('Unsupported file format. Please provide a .darshan file or a Recorder directory.')
+        sys.exit(1)
 
 
 def main():


### PR DESCRIPTION
Fixes #41

Previously, any path not ending in .darshan was assumed to be a Recorder directory, causing a misleading 'Unable to open recorder folder' error for unsupported file types like .txt or .csv.

Now explicitly checks if the path is a directory before treating it as a Recorder folder. If neither, displays a clear error: 'Unsupported file format. Please provide a .darshan file or a Recorder directory.'

<img width="1129" height="55" alt="image" src="https://github.com/user-attachments/assets/46a688b2-deb0-4c42-9c02-439a11b2e834" />
