### PR TITLE
Feature: Rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,19 @@ docker run --rm --mount \
 By default Drishti will generate an overview report in the console with recommendations:
 
 <p align="center">
-  <img src="https://github.com/hpc-io/io-insights/blob/master/images/sample-io-insights.svg?raw=true" alt="Drishti"/>
+  <img src="https://github.com/hpc-io/io-insights/blob/main/images/sample-io-insights.svg?raw=true" alt="Drishti"/>
 </p>
 
 You can also only list the issues detected by Drishti with `--issues`:
 
 <p align="center">
-  <img src="https://github.com/hpc-io/io-insights/blob/master/images/sample-io-insights-issues.svg?raw=true" alt="Drishti"/>
+  <img src="https://github.com/hpc-io/io-insights/blob/main/images/sample-io-insights-issues.svg?raw=true" alt="Drishti"/>
 </p>
 
 You can also enable the verbose mode with `--verbose` to visualize solution snippets:
 
 <p align="center">
-  <img src="https://github.com/hpc-io/io-insights/blob/master/images/sample-io-insights-verbose.svg?raw=true" alt="Drishti"/>
+  <img src="https://github.com/hpc-io/io-insights/blob/main/images/sample-io-insights-verbose.svg?raw=true" alt="Drishti"/>
 </p>
 
 ---


### PR DESCRIPTION
Hey! I took a look at this and went ahead and bumped the default branch to `main`. 

I just renamed it locally and verified all the hardcoded image links in the `README` (for the Darshan graphs) are pointing to `main` now so they don't break. 

The new branch is pushed up in this PR. Once it's merged, an admin will just need to quickly hop into the repo settings and swap the default branch over to `main` before we delete `master`. 

Let me know if this looks good!
