### PR TITLE
Feature: Replace Custom Byte Conversion with humanize.naturalsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,19 @@ docker run --rm --mount \
 By default Drishti will generate an overview report in the console with recommendations:
 
 <p align="center">
-  <img src="https://github.com/hpc-io/io-insights/blob/master/images/sample-io-insights.svg?raw=true" alt="Drishti"/>
+  <img src="https://github.com/hpc-io/io-insights/blob/main/images/sample-io-insights.svg?raw=true" alt="Drishti"/>
 </p>
 
 You can also only list the issues detected by Drishti with `--issues`:
 
 <p align="center">
-  <img src="https://github.com/hpc-io/io-insights/blob/master/images/sample-io-insights-issues.svg?raw=true" alt="Drishti"/>
+  <img src="https://github.com/hpc-io/io-insights/blob/main/images/sample-io-insights-issues.svg?raw=true" alt="Drishti"/>
 </p>
 
 You can also enable the verbose mode with `--verbose` to visualize solution snippets:
 
 <p align="center">
-  <img src="https://github.com/hpc-io/io-insights/blob/master/images/sample-io-insights-verbose.svg?raw=true" alt="Drishti"/>
+  <img src="https://github.com/hpc-io/io-insights/blob/main/images/sample-io-insights-verbose.svg?raw=true" alt="Drishti"/>
 </p>
 
 ---

--- a/drishti/includes/config.py
+++ b/drishti/includes/config.py
@@ -2,6 +2,7 @@
 
 import os
 import json
+import humanize
 
 from rich.console import Console, Group
 from rich.padding import Padding
@@ -188,25 +189,7 @@ def convert_bytes(bytes_number):
     """
     Convert bytes into formatted string.
     """
-    tags = [
-        'bytes',
-        'KB',
-        'MB',
-        'GB',
-        'TB',
-        'PB',
-        'EB'
-    ]
-
-    i = 0
-    double_bytes = bytes_number
-
-    while (i < len(tags) and bytes_number >= 1024):
-        double_bytes = bytes_number / 1024.0
-        i = i + 1
-        bytes_number = bytes_number / 1024
-
-    return str(round(double_bytes, 2)) + ' ' + tags[i] 
+    return humanize.naturalsize(bytes_number, binary=True, format="%.2f") 
 
 
 def message(code, target, level, issue, recommendations=None, details=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ darshan
 pandas>=2
 rich>=12.5.1
 recorder-utils
+humanize

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'darshan',
         'rich>=12.5.1',
         'recorder-utils',
+        'humanize',
     ],
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
Closes #28 

This PR replaces the custom `convert_bytes` function in `drishti/includes/config.py` with `humanize.naturalsize`. 

Changes:
- Removed the manual loop and list of byte tags.
- Implemented `humanize.naturalsize(bytes_number, binary=True, format="%.2f")` for robust formatting.
- Added `humanize` to `install_requires` in `setup.py` and `requirements.txt`.
